### PR TITLE
Refactor `gpio` module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,12 @@ version = "0.1.0"
 authors = ["Caio Tavares <caio.tavares11@gmail.com>", "José Cláudio S. Jr. <joseclaudio.silvajr@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
+cortex-m = "0.7.1"
+cortex-m-rt = "0.6.11"
 msp432p401r-pac = "0.1.0"
 cortex-m-semihosting = "0.3.3"
-embedded-hal = "1.0.0-alpha.3"
+embedded-hal = "1.0.0-alpha.4"
 
 [features]
-rt =  ["msp432p401r-pac/rt"]
+rt = ["msp432p401r-pac/rt"]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -6,15 +6,15 @@ use cortex_m_rt::entry;
 use panic_halt as _;
 // use cortex_m_semihosting::hprintln;                                      // Enable debug print
 
-extern crate msp432p401r_hal as hal;
-extern crate msp432p401r as pac;
+use msp432p401r_hal as hal;
+use msp432p401r as pac;
 
 use hal::watchdog::{WatchdogTimer, Enabled, Disable};
 use hal::gpio::{Output, ToggleableOutputPin, GPIO};
 use hal::gpio::porta::P1_0;
 use hal::clock::{ClockConfig, DIVM_A, DIVS_A, Clocks, DcoclkFreqSel};
 use hal::pcm::{PcmConfig, PcmDefined, VCoreSel};
-use hal::flctl::{FlctlConfig, FlcDefined, FlWaitSts};
+// use hal::flctl::{FlctlConfig, FlcDefined, FlWaitSts};
 
 #[entry]
 fn main() -> ! {
@@ -29,12 +29,16 @@ fn main() -> ! {
    let _pcm_sel = pcm.get_powermode();                                      // Get the current powermode
 
    // Flash Control Config.
-   let flctl = FlctlConfig::<FlcDefined>::new();                            // Setup FlctlConfig
-   flctl.set_flwaitst(FlWaitSts::_2Ws);                                     // Two wait states -> 48 Mhz Clock
+   // let flctl = FlctlConfig::<FlcDefined>::new();                            // Setup FlctlConfig
+   // flctl.set_flwaitst(FlWaitSts::_2Ws);                                     // Two wait states -> 48 Mhz Clock
 
    // hprintln!("Hello World Example").unwrap();
 
-   let mut p1_0: P1_0<GPIO<Output>> = P1_0::<GPIO<Output>>::into_output();
+   let p = pac::Peripherals::take().unwrap();
+
+   let dio = p.DIO;
+   let gpio = dio.split();
+   let mut p1_0 = gpio.p1_0.into_output();
 
    let _clock :Clocks = ClockConfig::new()
         .mclk_dcoclk( DcoclkFreqSel::_48MHz, DIVM_A::DIVM_0)

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -14,7 +14,7 @@ use hal::gpio::{Output, ToggleableOutputPin, GPIO};
 use hal::gpio::porta::P1_0;
 use hal::clock::{ClockConfig, DIVM_A, DIVS_A, Clocks, DcoclkFreqSel};
 use hal::pcm::{PcmConfig, PcmDefined, VCoreSel};
-// use hal::flctl::{FlctlConfig, FlcDefined, FlWaitSts};
+use hal::flctl::{FlctlConfig, FlcDefined, FlWaitSts};
 
 #[entry]
 fn main() -> ! {
@@ -29,8 +29,8 @@ fn main() -> ! {
    let _pcm_sel = pcm.get_powermode();                                      // Get the current powermode
 
    // Flash Control Config.
-   // let flctl = FlctlConfig::<FlcDefined>::new();                            // Setup FlctlConfig
-   // flctl.set_flwaitst(FlWaitSts::_2Ws);                                     // Two wait states -> 48 Mhz Clock
+   let flctl = FlctlConfig::<FlcDefined>::new();                            // Setup FlctlConfig
+   flctl.set_flwaitst(FlWaitSts::_2Ws);                                     // Two wait states -> 48 Mhz Clock
 
    // hprintln!("Hello World Example").unwrap();
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -481,11 +481,11 @@ impl<'a, SMCLK: SmclkState> ClockConfig<MclkDefined, SMCLK> {
         if let MclkSel::Dcoclk(target_freq) = self.mclk.0 {
             self.cs.csctl0.write(|w|  { w.dcorsel().variant(target_freq.dcorsel()) });
 
-               for _n in 1..50 {
-                   unsafe{llvm_asm!("NOP")};
-               }
-            };
-        }
+            for _n in 1..50 {
+                unsafe{llvm_asm!("NOP")};
+            }
+        };
+    }
 
     #[inline]
     fn configure_hfxt(&self) {

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,4 +1,4 @@
-//! HAL library for CS (Clock Source) - MSP432P401R
+//! HAL library for CS (Clock System) - MSP432P401R
 
 /*
 +--------+-----------------------+---------------+-------------------------------------------------+
@@ -50,12 +50,24 @@ BCLK is software selectable as LFXTCLK and REFOCLK and is used primarily in the 
 BCLK is restricted to a maximum frequency of 32.768 kHz
 */
 
+use cortex_m::interrupt;
+
 use crate::time::Hertz;
 use pac::cs::csctl0::DCORSEL_A;
 use pac::cs::csctl2::HFXTFREQ_A;
 pub use pac::cs::csctl1::{SELS_A, SELA_A, SELM_A, DIVM_A, DIVS_A};
 use pac::cs::csclken::REFOFSEL_A;
 use pac::CS;
+
+pub trait CsExt {
+    fn constrain(self) -> ClockConfig<NoClockDefined, NoClockDefined>;
+}
+
+impl CsExt for CS {
+    fn constrain(self) -> ClockConfig<NoClockDefined, NoClockDefined> {
+        ClockConfig::new(self)
+    }
+}
 
 /// Typestate for `ClockConfig` that represents unconfigured clocks
 pub struct NoClockDefined;
@@ -76,7 +88,7 @@ pub const HFXTMINCLK: u32 = 1_000_000;
 pub const HFXTMAXCLK: u32 = 48_000_000;
 
 ///Selectable HFXTCLK frequencies
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum HfxtclkFreqSel {
     // 1-4 MHz
     _1_4MHz,
@@ -96,7 +108,7 @@ pub enum HfxtclkFreqSel {
 
 impl HfxtclkFreqSel {
     #[inline(always)]
-    fn hfxtsel(&self) -> HFXTFREQ_A {
+    const fn hfxtsel(&self) -> HFXTFREQ_A {
         match *self {
             HfxtclkFreqSel::_1_4MHz => HFXTFREQ_A::HFXTFREQ_0,
             HfxtclkFreqSel::_4_8MHz => HFXTFREQ_A::HFXTFREQ_1,
@@ -110,7 +122,7 @@ impl HfxtclkFreqSel {
 
     /// Numerical frequency
     #[inline]
-    pub fn freq(&self) -> u32 {
+    pub const fn freq(&self) -> u32 {
         match *self {
             HfxtclkFreqSel::_1_4MHz => 4_000_000,
             HfxtclkFreqSel::_4_8MHz => 8_000_000,
@@ -125,7 +137,7 @@ impl HfxtclkFreqSel {
 
 /// Selectable REFOCLK frequencies
 /// Default: 32.768 KHz
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum RefoclkFreqSel {
     // 32.738 KHz
     _32_768,
@@ -154,7 +166,7 @@ impl RefoclkFreqSel {
 
 /// Selectable DCOCLK frequencies when using factory trim settings.
 /// Actual frequencies may be slightly higher.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum DcoclkFreqSel {
     /// 1,5 MHz
     _1_5MHz,
@@ -198,6 +210,7 @@ impl DcoclkFreqSel {
 }
 
 // ***** Mclk *****
+#[derive(Debug)]
 enum MclkSel {
     Vloclk,
     Modclk,
@@ -234,6 +247,7 @@ impl MclkSel {
 }
 
 // ***** HSMclk *****
+#[derive(Debug)]
 enum HSMclkSel {
     Vloclk,
     Modclk,
@@ -314,8 +328,8 @@ impl SmclkState for SmclkDefined {
 /// Builder object that configures system clocks
 /// Can only commit configurations to hardware if both MCLK (HSMCLK) and SMCLK settings have been
 /// configured. ACLK and BCLK configurations are optional, with its default source being REFOCLK.
-pub struct ClockConfig<'a, MCLK, SMCLK> {
-    periph: &'a pac::cs::RegisterBlock,
+pub struct ClockConfig<MCLK, SMCLK> {
+    cs: CS,
     mclk: MCLK,
     mclk_div: DIVM_A,
     aclk_sel: AclkSel,
@@ -326,7 +340,7 @@ pub struct ClockConfig<'a, MCLK, SMCLK> {
 macro_rules! make_clkconf {
     ($conf:expr, $mclk:expr, $smclk:expr) => {
         ClockConfig {
-            periph: $conf.periph,
+            cs: $conf.cs,
             mclk: $mclk,
             mclk_div: $conf.mclk_div,
             aclk_sel: $conf.aclk_sel,
@@ -336,14 +350,11 @@ macro_rules! make_clkconf {
     };
 }
 
-impl <'a>ClockConfig<'a, NoClockDefined, NoClockDefined> {
+impl ClockConfig<NoClockDefined, NoClockDefined> {
     /// Converts CS into a fresh, unconfigured clock builder object
-    pub fn new() -> Self {
-
-        let cs = unsafe { &*CS::ptr() };
-
+    fn new(cs: CS) -> Self {
         ClockConfig {
-            periph: cs,
+            cs,
             smclk: NoClockDefined,
             mclk: NoClockDefined,
             mclk_div: DIVM_A::DIVM_0,
@@ -353,7 +364,7 @@ impl <'a>ClockConfig<'a, NoClockDefined, NoClockDefined> {
     }
 }
 
-impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
+impl<MCLK, SMCLK> ClockConfig<MCLK, SMCLK> {
     /// Select LFXTCLK for ACLK
     #[inline]
     pub fn aclk_lfxtclk(mut self) -> Self {
@@ -377,7 +388,7 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
 
     /// Select REFOCLK for MCLK and set the MCLK divider. Frequency is `REFOCLK / mclk_div` Hz.
     #[inline]
-    pub fn mclk_refoclk(self, target_freq: RefoclkFreqSel, mclk_div: DIVM_A) -> ClockConfig<'a, MclkDefined, SMCLK> {
+    pub fn mclk_refoclk(self, target_freq: RefoclkFreqSel, mclk_div: DIVM_A) -> ClockConfig<MclkDefined, SMCLK> {
 
         let smclk_sel = HSMclkSel::Refoclk(target_freq);
 
@@ -390,7 +401,7 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
 
     /// Select LFXTCLK for MCLK and set the MCLK divider. Frequency is `LFXTCLK / mclk_div` Hz.
     #[inline]
-    pub fn mclk_lfxtclk(self, mclk_div: DIVM_A) -> ClockConfig<'a, MclkDefined, SMCLK> {
+    pub fn mclk_lfxtclk(self, mclk_div: DIVM_A) -> ClockConfig<MclkDefined, SMCLK> {
 
         let smclk_sel = HSMclkSel::Lfxtclk;
 
@@ -403,7 +414,7 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
 
     /// Select MODCLK for MCLK and set the MCLK divider. Frequency is `MODCLK / mclk_div` Hz.
     #[inline]
-    pub fn mclk_modclk(self, mclk_div: DIVM_A) -> ClockConfig<'a, MclkDefined, SMCLK> {
+    pub fn mclk_modclk(self, mclk_div: DIVM_A) -> ClockConfig<MclkDefined, SMCLK> {
 
         let smclk_sel = HSMclkSel::Modclk;
 
@@ -416,7 +427,7 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
 
     /// Select VLOCLK for MCLK and set the MCLK divider. Frequency is `VLO / mclk_div` Hz.
     #[inline]
-    pub fn mclk_vloclk(self, mclk_div: DIVM_A) -> ClockConfig<'a, MclkDefined, SMCLK> {
+    pub fn mclk_vloclk(self, mclk_div: DIVM_A) -> ClockConfig<MclkDefined, SMCLK> {
 
         let smclk_sel = HSMclkSel::Vloclk;
 
@@ -429,7 +440,7 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
 
     /// Select HFXTCLK for MCLK and set the MCLK divider. Frequency is `HFXTCLK / mclk_div` Hz.
     #[inline]
-    pub fn mclk_hfxtclk(self, target_freq: HfxtclkFreqSel, mclk_div: DIVM_A) -> ClockConfig<'a, MclkDefined, SMCLK> {
+    pub fn mclk_hfxtclk(self, target_freq: HfxtclkFreqSel, mclk_div: DIVM_A) -> ClockConfig<MclkDefined, SMCLK> {
 
         let smclk_sel = HSMclkSel::Hfxtclk(target_freq);
 
@@ -444,7 +455,7 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
     /// This setting selects the default factory trim for DCO trimming and performs no extra
     /// calibration, so only a select few frequency targets can be selected.
     #[inline]
-    pub fn mclk_dcoclk(self, target_freq: DcoclkFreqSel, mclk_div: DIVM_A) -> ClockConfig<'a, MclkDefined, SMCLK> {
+    pub fn mclk_dcoclk(self, target_freq: DcoclkFreqSel, mclk_div: DIVM_A) -> ClockConfig<MclkDefined, SMCLK> {
 
         let smclk_sel = HSMclkSel::Dcoclk(target_freq);
 
@@ -457,18 +468,18 @@ impl<'a, MCLK, SMCLK> ClockConfig<'a, MCLK, SMCLK> {
 
     /// Enable SMCLK and set SMCLK divider, which divides the MCLK frequency
     #[inline]
-    pub fn smclk_div(self, div: DIVS_A) -> ClockConfig<'a, MCLK, SmclkDefined> {
+    pub fn smclk_div(self, div: DIVS_A) -> ClockConfig<MCLK, SmclkDefined> {
         make_clkconf!(self, self.mclk, SmclkDefined(div))
     }
 }
 
-impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
+impl<'a, SMCLK: SmclkState> ClockConfig<MclkDefined, SMCLK> {
 
     #[inline]
     fn configure_dco_fll(&self) {
         // Run DCO configuration
         if let MclkSel::Dcoclk(target_freq) = self.mclk.0 {
-            self.periph.csctl0.write(|w|  { w.dcorsel().variant(target_freq.dcorsel()) });
+            self.cs.csctl0.write(|w|  { w.dcorsel().variant(target_freq.dcorsel()) });
 
                for _n in 1..50 {
                    unsafe{llvm_asm!("NOP")};
@@ -480,7 +491,7 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
     fn configure_hfxt(&self) {
         // Run HFXT configuration
         if let MclkSel::Hfxtclk(target_freq) = self.mclk.0 {
-            self.periph.csctl2.write(|w|  { w.hfxtfreq().variant(target_freq.hfxtsel()) });
+            self.cs.csctl2.write(|w|  { w.hfxtfreq().variant(target_freq.hfxtsel()) });
 
             for _n in 1..50 {
                 unsafe{llvm_asm!("NOP")};
@@ -492,11 +503,11 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
     fn configure_refo(&self) {
         // Run REFO configuration
         if let MclkSel::Refoclk(target_freq) = self.mclk.0 {
-            self.periph.csclken.write(|w|  { w.refofsel().variant(target_freq.refofsel()) })
+            self.cs.csclken.write(|w|  { w.refofsel().variant(target_freq.refofsel()) })
         };
 
         if let AclkSel::Refoclk(target_freq) = self.aclk_sel {
-            self.periph.csclken.write(|w|  { w.refofsel().variant(target_freq.refofsel()) })
+            self.cs.csclken.write(|w|  { w.refofsel().variant(target_freq.refofsel()) })
         };
     }
 
@@ -512,7 +523,7 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
         self.wait_clk(CS_STAT);
 
         // ACLK SEL
-        self.periph.csctl1.modify(|r, w| unsafe {
+        self.cs.csctl1.modify(|r, w| unsafe {
             w.bits(r.bits() & CS_MASK_ACLK)
              .sela().variant(self.aclk_sel.sela())
         });
@@ -520,7 +531,7 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
         self.wait_clk(CS_STAT);
 
         // MCLK SEL | MCLK DIV
-        self.periph.csctl1.modify(|r, w| unsafe {
+        self.cs.csctl1.modify(|r, w| unsafe {
             w.bits(r.bits() & CS_MASK_MCLK)
              .selm().variant(self.mclk.0.selm())
              .divm().variant(self.mclk_div)
@@ -529,7 +540,7 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
         self.wait_clk(CS_STAT);
 
         // SMCLK SEL | SMCLK DIV
-        self.periph.csctl1.modify(|r, w| unsafe {
+        self.cs.csctl1.modify(|r, w| unsafe {
             w.bits(r.bits() & CS_MASK_SMCLK)
              .sels().variant(self.smclk_sel.sels());
             match self.smclk.div() {
@@ -548,9 +559,9 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
         const CSKEY: u32 = 0x695A;
 
         if keylock{
-            self.periph.cskey.write(|w| unsafe { w.bits(CSKEY) });
+            self.cs.cskey.write(|w| unsafe { w.bits(CSKEY) });
         } else {
-            self.periph.cskey.write(|w| unsafe { w.bits(!CSKEY) });
+            self.cs.cskey.write(|w| unsafe { w.bits(!CSKEY) });
         }
     }
 
@@ -561,50 +572,38 @@ impl<'a, SMCLK: SmclkState> ClockConfig<'a, MclkDefined, SMCLK> {
             unsafe{llvm_asm!("NOP")};
        }
 
-       while ((self.periph.csstat.read().bits() >> 24) as u8 & flag) != flag {
+       while ((self.cs.csstat.read().bits() >> 24) as u8 & flag) != flag {
             unsafe{llvm_asm!("NOP")};
        };
     }
 }
 
-impl <'a>ClockConfig<'a, MclkDefined, SmclkDefined> {
-
+impl ClockConfig<MclkDefined, SmclkDefined> {
     /// Apply clock configuration to hardware and return clock objects
     #[inline]
     pub fn freeze(self) -> Clocks {
+        interrupt::free(|_| {
+            self.cs_key(true);
 
-        let mut status: u32;
+            self.configure_dco_fll();
+            self.configure_hfxt();
+            self.configure_refo();
+            self.configure_cs();
 
-        /* save the PRIMASK into 'status' */
-        unsafe { llvm_asm!("mrs $0, PRIMASK" : "=r" (status) : : : "volatile") };
+            self.cs_key(false);
+        });
 
-        /* set PRIMASK to disable interrupts */
-        unsafe { llvm_asm!("cpsid i" : : : : "volatile") };
-
-        let mclk_freq = self.mclk.0.freq().clone() >> (self.mclk_div.clone() as u32);
-
-        self.cs_key(true);
-
-        self.configure_dco_fll();
-        self.configure_hfxt();
-        self.configure_refo();
-        self.configure_cs();
-
-        self.cs_key(false);
-
-        /* restore PRIMASK from 'status' */
-        unsafe { llvm_asm!("msr PRIMASK, $0" : : "r" (status) : : "volatile") };
-
-        let aclk_freq :u32 = self.aclk_sel.freq().clone();
-        let hsmclk_freq :u32 = self.smclk_sel.freq().clone();
-        let _smclk_freq :u32 = self.smclk_sel.freq().clone()/(self.smclk.0.clone() as u32);
+        let aclk_freq :u32 = self.aclk_sel.freq();
+        let mclk_freq = self.mclk.0.freq() >> self.mclk_div as u32;
+        let hsmclk_freq :u32 = self.smclk_sel.freq();
+        let smclk_freq :u32 = self.smclk_sel.freq() / self.smclk.0 as u32;
 
         let clocks = Clocks {
             aclk: Hertz(aclk_freq),
             mclk: Hertz(mclk_freq),
             hsmclk: Hertz(hsmclk_freq),
-            smclk: Hertz(_smclk_freq),
-            bclk: Hertz(aclk_freq.clone()),
+            smclk: Hertz(smclk_freq),
+            bclk: Hertz(aclk_freq),
         };
 
         clocks

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -266,6 +266,17 @@ macro_rules! gpio {
                             }
                         }
 
+                        impl StatefulOutputPin for $PI_i<Output> {
+                            fn try_is_set_high(&self) -> Result<bool, Self::Error> {
+                                self.try_is_set_low().map(|b| !b)
+                            }
+
+                            fn try_is_set_low(&self) -> Result<bool, Self::Error> {
+                                let dio = unsafe { &*$DIO::ptr() };
+                                Ok(dio.$pxout.read().$piout().bits() & (1 << $i) == 0)
+                            }
+                        }
+
                         impl ToggleableOutputPin for $PI_i<Output> {
                             type Error = Infallible;
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -2,98 +2,89 @@ use core::marker::PhantomData;
 
 pub use hal::digital::{InputPin, OutputPin, ToggleableOutputPin};
 
-pub trait InputMode {}
-
-pub trait OutputMode {}
-
-pub trait FunctionMode {}
-
-pub struct PulledUpInput;
-
-pub struct PulledDownInput;
-
-pub struct FloatingInput;
-
-pub struct RegularDrive;
-
-pub struct HighDrive;
-
-pub struct Output;
-
-pub struct PrimaryModuleFunction;
-
-pub struct SecondaryModuleFunction;
-
-pub struct TertiaryModuleFunction;
-
-impl InputMode for PulledUpInput {}
-
-impl InputMode for PulledDownInput {}
-
-impl InputMode for FloatingInput {}
-
-impl OutputMode for RegularDrive {}
-
-impl OutputMode for HighDrive {}
-
-impl OutputMode for Output {}
-
-impl FunctionMode for PrimaryModuleFunction {}
-
-impl FunctionMode for SecondaryModuleFunction {}
-
-impl FunctionMode for TertiaryModuleFunction {}
-
-pub struct GPIO<T> {
-    _mode: PhantomData<T>
+pub struct Input<MODE> {
+    _mode: PhantomData<MODE>,
 }
 
-pub struct AlternateFunction<T> where T: FunctionMode {
-    _mode: PhantomData<T>
+impl<MODE> Input<MODE> {
+    const fn _new() -> Self {
+        Self { _mode: PhantomData }
+    }
+}
+
+pub struct Floating;
+pub struct PullDown;
+pub struct PullUp;
+
+pub struct Output {
+    _mode: PhantomData<()>,
+}
+
+impl Output {
+    const fn _new() -> Self {
+        Self { _mode: PhantomData }
+    }
+}
+
+pub struct Alternate<MODE> {
+    _mode: PhantomData<MODE>,
+}
+
+impl<MODE> Alternate<MODE> {
+    const fn _new() -> Self {
+        Self { _mode: PhantomData }
+    }
+}
+
+pub struct Primary;
+pub struct Secondary;
+pub struct Tertiary;
+
+/// Extension trait to split a GPIO peripheral in independent pins and registers
+pub trait GpioExt {
+    /// The to split the GPIO into
+    type Parts;
+
+    /// Splits the GPIO block into independent pins and registers
+    fn split(self) -> Self::Parts;
 }
 
 macro_rules! gpio {
-    ($portx:ident, $pxdir:ident, $pxout:ident, $pxin:ident, $pxren:ident, $pxsel0:ident, $pxsel1:ident, $PXx: ident, {
-        $($PIx:ident: [
+    ($DIO:ident, {
+        $(($portx:ident, $pxdir:ident, $pxout:ident, $pxin:ident, $pxren:ident, $pxsel0:ident, $pxsel1:ident, $PXx:ident): {
+          $($PIx:ident: [
             $($PI_i:ident: ($pxi:ident, $i:expr, $j:expr, $pidir:ident, $piout:ident, $piin:ident, $piren:ident, $pisel0:ident, $pisel1:ident, $MODE:ty),)+
-        ])+
+          ])+
+        })+
     }) => {
+        $(
             pub mod $portx {
                 use hal::digital::{OutputPin, InputPin, ToggleableOutputPin};
+                use core::convert::Infallible;
                 use core::marker::PhantomData;
                 use super::*;
-                use pac::DIO;
 
                 /// Port Group Implementation (PA, PB, PC...)
                 pub struct $PXx<MODE> {
-                #[allow(dead_code)]
-                    i: u8,
                     _mode: PhantomData<MODE>,
                 }
 
                 /// Port Implementation (P1, P2, P3..)
                 $(
                     pub struct $PIx<MODE> {
-                    #[allow(dead_code)]
-                        i: u8,
                         _mode: PhantomData<MODE>,
                     }
 
                     /// Pin Implementation (P1_1, P1_2...)
                     $(
                         pub struct $PI_i<MODE> {
-                            _mode: PhantomData<MODE>,
+                            pub(crate) _mode: MODE,
                         }
 
                         impl<MODE> $PI_i<MODE> {
-                            /// Get default state for Pin
-                            pub fn default() -> $PI_i<$MODE> {
-                                $PI_i::<$MODE> { _mode: PhantomData }
-                            }
-
                             /// Setup PullUp resistor and configures Pin to Input mode
-                            pub fn into_pulled_up_input() -> $PI_i<GPIO<PulledUpInput>> {
-                                let dio = unsafe { &*DIO::ptr() };
+                            pub fn into_pull_up_input(self) -> $PI_i<Input<PullUp>> {
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxdir.modify(|r,w| unsafe {
                                     w.$pidir().bits(r.$pidir().bits() & !(0x01 << $i))
                                 });
@@ -103,12 +94,12 @@ macro_rules! gpio {
                                 dio.$pxout.modify(|r,w| unsafe {
                                     w.$piout().bits(r.$piout().bits() | (0x01 << $i))
                                 });
-                                $PI_i::<GPIO<PulledUpInput>> { _mode: PhantomData }
+                                $PI_i { _mode: Input::_new() }
                             }
 
                             /// Setup PullDown resistor and configures Pin to Input mode
-                            pub fn into_pulled_down_input() -> $PI_i<GPIO<PulledDownInput>> {
-                                let dio = unsafe { &*DIO::ptr() };
+                            pub fn into_pull_down_input(self) -> $PI_i<Input<PullDown>> {
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxdir.modify(|r,w| unsafe {
                                     w.$pidir().bits(r.$pidir().bits() & !(0x01 << $i))
                                 });
@@ -118,89 +109,87 @@ macro_rules! gpio {
                                 dio.$pxout.modify(|r,w| unsafe {
                                     w.$piout().bits(r.$piout().bits() & !(0x01 << $i))
                                 });
-                                $PI_i::<GPIO<PulledDownInput>> { _mode: PhantomData }
+                                $PI_i { _mode: Input::_new() }
                             }
 
                             /// Disables PullUp/PullDown resistor and configures Pin to Input mode
-                            pub fn into_floating_input() -> $PI_i<GPIO<FloatingInput>> {
-                                let dio = unsafe { &*DIO::ptr() };
+                            pub fn into_floating_input(self) -> $PI_i<Input<Floating>> {
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxdir.modify(|r,w| unsafe {
                                     w.$pidir().bits(r.$pidir().bits() & !(0x01 << $i))
                                 });
                                 dio.$pxren.modify(|r,w| unsafe {
                                     w.$piren().bits(r.$piren().bits() & !(0x01 << $i))
                                 });
-                                $PI_i::<GPIO<FloatingInput>> { _mode: PhantomData }
+                                $PI_i { _mode: Input::_new() }
                             }
 
                             // TODO: Implement Drive Selection register
                             /// Setup Pin to output mode
-                            pub fn into_output() -> $PI_i<GPIO<Output>> {
-                                let dio = unsafe { &*DIO::ptr() };
+                            pub fn into_output(self) -> $PI_i<Output> {
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxdir.modify(|r,w| unsafe {
                                     w.$pidir().bits(r.$pidir().bits() | (0x01 << $i))
                                 });
-                                $PI_i::<GPIO<Output>> { _mode: PhantomData }
+                                $PI_i { _mode: Output::_new() }
                             }
 
                             /// Setup Primary Module Function
-                            pub fn into_primary_module_function() -> $PI_i<AlternateFunction<PrimaryModuleFunction>> {
-                                let dio = unsafe { &*DIO::ptr() };
-                                dio.$pxsel0.modify(|r,w| unsafe {
-                                    w.$pisel0().bits(r.$pisel0().bits() | (0x01 << $i))
-                                });
+                            pub fn into_alternate_primary(self) -> $PI_i<Alternate<Primary>> {
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxsel1.modify(|r,w| unsafe {
                                     w.$pisel1().bits(r.$pisel1().bits() & !(0x01 << $i))
                                 });
-                                $PI_i::<AlternateFunction<PrimaryModuleFunction>> { _mode: PhantomData }
-                            }
-
-                            /// Setup Secondary Module Function
-                            pub fn into_secondary_module_function() -> $PI_i<AlternateFunction<SecondaryModuleFunction>> {
-                                let dio = unsafe { &*DIO::ptr() };
-                                dio.$pxsel0.modify(|r,w| unsafe {
-                                    w.$pisel0().bits(r.$pisel0().bits() & !(0x01 << $i))
-                                });
-                                dio.$pxsel1.modify(|r,w| unsafe {
-                                    w.$pisel1().bits(r.$pisel1().bits() | (0x01 << $i))
-                                });
-                                $PI_i::<AlternateFunction<SecondaryModuleFunction>> { _mode: PhantomData }
-                            }
-
-                            /// Setup Tertiary Module Function
-                            pub fn into_tertiary_module_function() -> $PI_i<AlternateFunction<TertiaryModuleFunction>> {
-                                let dio = unsafe { &*DIO::ptr() };
                                 dio.$pxsel0.modify(|r,w| unsafe {
                                     w.$pisel0().bits(r.$pisel0().bits() | (0x01 << $i))
                                 });
+                                $PI_i { _mode: Alternate::_new() }
+                            }
+
+                            /// Setup Secondary Module Function
+                            pub fn into_alternate_secondary(self) -> $PI_i<Alternate<Secondary>> {
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxsel1.modify(|r,w| unsafe {
                                     w.$pisel1().bits(r.$pisel1().bits() | (0x01 << $i))
                                 });
-                                $PI_i::<AlternateFunction<TertiaryModuleFunction>> { _mode: PhantomData }
+                                dio.$pxsel0.modify(|r,w| unsafe {
+                                    w.$pisel0().bits(r.$pisel0().bits() & !(0x01 << $i))
+                                });
+                                $PI_i { _mode: Alternate::_new() }
+                            }
+
+                            /// Setup Tertiary Module Function
+                            pub fn into_alternate_tertiary(self) -> $PI_i<Alternate<Tertiary>> {
+                                let dio = unsafe { &*$DIO::ptr() };
+                                dio.$pxsel1.modify(|r,w| unsafe {
+                                    w.$pisel1().bits(r.$pisel1().bits() | (0x01 << $i))
+                                });
+                                dio.$pxsel0.modify(|r,w| unsafe {
+                                    w.$pisel0().bits(r.$pisel0().bits() | (0x01 << $i))
+                                });
+                                $PI_i { _mode: Alternate::_new() }
                             }
                         }
 
-                        impl<M: InputMode> InputPin for $PI_i<GPIO<M>> {
-                            type Error = ();
+                        impl<MODE> InputPin for $PI_i<Input<MODE>> {
+                            type Error = Infallible;
 
                             fn try_is_high(&self) -> Result<bool, Self::Error> {
-                                let dio = unsafe { &*DIO::ptr() };
-                                let state = (dio.$pxin.read().$piin().bits() & (0x01 << $i)) > 0;
-                                Ok(state)
+                                self.try_is_low().map(|low| !low)
                             }
 
                             fn try_is_low(&self) -> Result<bool, Self::Error> {
-                                let dio = unsafe { &*DIO::ptr() };
-                                let state = (!dio.$pxin.read().$piin().bits() & (0x01 << $i)) > 0;
+                                let dio = unsafe { &*$DIO::ptr() };
+                                let state = (dio.$pxin.read().$piin().bits() & (0x01 << $i)) == 0;
                                 Ok(state)
                             }
                         }
 
-                        impl OutputPin for $PI_i<GPIO<Output>> {
-                            type Error = ();
+                        impl OutputPin for $PI_i<Output> {
+                            type Error = Infallible;
 
                             fn try_set_low(&mut self) -> Result<(), Self::Error> {
-                                let dio = unsafe { &*DIO::ptr() };
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxout.modify(|r,w| unsafe {
                                     w.$piout().bits(r.$piout().bits() & !(0x01 << $i))
                                 });
@@ -208,7 +197,7 @@ macro_rules! gpio {
                             }
 
                             fn try_set_high(&mut self) -> Result<(), Self::Error> {
-                                let dio = unsafe { &*DIO::ptr() };
+                                let dio = unsafe { &*$DIO::ptr() };
                                 dio.$pxout.modify(|r,w| unsafe {
                                     w.$piout().bits(r.$piout().bits() | (0x01 << $i))
                                 });
@@ -216,11 +205,11 @@ macro_rules! gpio {
                             }
                         }
 
-                        impl ToggleableOutputPin for $PI_i<GPIO<Output>> {
-                            type Error = ();
+                        impl ToggleableOutputPin for $PI_i<Output> {
+                            type Error = Infallible;
 
                             fn try_toggle(&mut self) -> Result<(), Self::Error> {
-                                let dio = unsafe { &*DIO::ptr() };
+                                let dio = unsafe { &*$DIO::ptr() };
                                     dio.$pxout.modify(|r,w| unsafe {
                                     w.$piout().bits(r.$piout().bits() ^ (0x01 << $i))
                                 });
@@ -229,129 +218,140 @@ macro_rules! gpio {
                         }
                     )+
                 )+
+            }
+        )+
 
-                pub struct Parts {
-                    $(
-                        $(
-                            pub $pxi: $PI_i<$MODE>,
-                        )+
-                    )+
+        pub struct Parts {
+            $($($(
+                pub $pxi: $portx::$PI_i<$MODE>,
+            )+)+)+
+        }
+
+        impl GpioExt for $DIO {
+            type Parts = Parts;
+
+            fn split(self) -> Parts {
+                Parts {
+                    $($($(
+                        $pxi: $portx::$PI_i { _mode: <$MODE>::_new() },
+                    )+)+)+
                 }
             }
+        }
     }
 }
 
-gpio!(porta, padir, paout, pain, paren, pasel0, pasel1, PAx, {
-    P1x: [
-        P1_0: (p1_0, 0, 0, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_1: (p1_1, 1, 1, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_2: (p1_2, 2, 2, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_3: (p1_3, 3, 3, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_4: (p1_4, 4, 4, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_5: (p1_5, 5, 5, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_6: (p1_6, 6, 6, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-        P1_7: (p1_7, 7, 7, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, GPIO<FloatingInput>),
-    ]
-    P2x: [
-        P2_0: (p2_0, 0,  8, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_1: (p2_1, 1,  9, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_2: (p2_2, 2, 10, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_3: (p2_3, 3, 11, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_4: (p2_4, 4, 12, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_5: (p2_5, 5, 13, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_6: (p2_6, 6, 14, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-        P2_7: (p2_7, 7, 15, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, GPIO<FloatingInput>),
-    ]
-});
+use pac::DIO;
 
-gpio!(portb, pbdir, pbout, pbin, pbren, pbsel0, pbsel1, PBx, {
-    P3x: [
-        P3_0: (p3_0, 0, 0, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_1: (p3_1, 1, 1, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_2: (p3_2, 2, 2, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_3: (p3_3, 3, 3, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_4: (p3_4, 4, 4, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_5: (p3_5, 5, 5, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_6: (p3_6, 6, 6, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-        P3_7: (p3_7, 7, 7, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, GPIO<FloatingInput>),
-    ]
-    P4x: [
-        P4_0: (p4_0, 0,  8, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_1: (p4_1, 1,  9, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_2: (p4_2, 2, 10, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_3: (p4_3, 3, 11, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_4: (p4_4, 4, 12, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_5: (p4_5, 5, 13, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_6: (p4_6, 6, 14, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-        P4_7: (p4_7, 7, 15, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, GPIO<FloatingInput>),
-    ]
-});
-
-gpio!(portc, pcdir, pcout, pcin, pcren, pcsel0, pcsel1, PCx, {
-    P5x: [
-        P5_0: (p5_0, 0, 0, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_1: (p5_1, 1, 1, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_2: (p5_2, 2, 2, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_3: (p5_3, 3, 3, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_4: (p5_4, 4, 4, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_5: (p5_5, 5, 5, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_6: (p5_6, 6, 6, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-        P5_7: (p5_7, 7, 7, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, GPIO<FloatingInput>),
-    ]
-    P6x: [
-        P6_0: (p6_0, 0,  8, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_1: (p6_1, 1,  9, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_2: (p6_2, 2, 10, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_3: (p6_3, 3, 11, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_4: (p6_4, 4, 12, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_5: (p6_5, 5, 13, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_6: (p6_6, 6, 14, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-        P6_7: (p6_7, 7, 15, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, GPIO<FloatingInput>),
-    ]
-});
-
-gpio!(portd, pddir, pdout, pdin, pdren, pdsel0, pdsel1, PDx, {
-    P7x: [
-        P7_0: (p7_0, 0, 0, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_1: (p7_1, 1, 1, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_2: (p7_2, 2, 2, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_3: (p7_3, 3, 3, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_4: (p7_4, 4, 4, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_5: (p7_5, 5, 5, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_6: (p7_6, 6, 6, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-        P7_7: (p7_7, 7, 7, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, GPIO<FloatingInput>),
-    ]
-    P8x: [
-        P8_0: (p8_0, 0,  8, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_1: (p8_1, 1,  9, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_2: (p8_2, 2, 10, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_3: (p8_3, 3, 11, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_4: (p8_4, 4, 12, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_5: (p8_5, 5, 13, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_6: (p8_6, 6, 14, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-        P8_7: (p8_7, 7, 15, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, GPIO<FloatingInput>),
-    ]
-});
-
-gpio!(porte, pedir, peout, pein, peren, pesel0, pesel1, PEx, {
-    P9x: [
-        P9_0: (p9_0, 0, 0, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_1: (p9_1, 1, 1, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_2: (p9_2, 2, 2, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_3: (p9_3, 3, 3, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_4: (p9_4, 4, 4, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_5: (p9_5, 5, 5, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_6: (p9_6, 6, 6, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-        P9_7: (p9_7, 7, 7, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, GPIO<FloatingInput>),
-    ]
-    P10x: [
-        P10_0: (p10_0, 0,  8, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_1: (p10_1, 1,  9, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_2: (p10_2, 2, 10, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_3: (p10_3, 3, 11, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_4: (p10_4, 4, 12, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_5: (p10_5, 5, 13, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_6: (p10_6, 6, 14, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-        P10_7: (p10_7, 7, 15, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, GPIO<FloatingInput>),
-    ]
+gpio!(DIO, {
+    (porta, padir, paout, pain, paren, pasel0, pasel1, PAx): {
+        P1x: [
+            P1_0: (p1_0, 0, 0, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_1: (p1_1, 1, 1, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_2: (p1_2, 2, 2, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_3: (p1_3, 3, 3, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_4: (p1_4, 4, 4, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_5: (p1_5, 5, 5, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_6: (p1_6, 6, 6, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_7: (p1_7, 7, 7, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+        ]
+        P2x: [
+            P2_0: (p2_0, 0,  8, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_1: (p2_1, 1,  9, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_2: (p2_2, 2, 10, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_3: (p2_3, 3, 11, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_4: (p2_4, 4, 12, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_5: (p2_5, 5, 13, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_6: (p2_6, 6, 14, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_7: (p2_7, 7, 15, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+        ]
+    }
+    (portb, pbdir, pbout, pbin, pbren, pbsel0, pbsel1, PBx): {
+        P3x: [
+            P3_0: (p3_0, 0, 0, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_1: (p3_1, 1, 1, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_2: (p3_2, 2, 2, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_3: (p3_3, 3, 3, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_4: (p3_4, 4, 4, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_5: (p3_5, 5, 5, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_6: (p3_6, 6, 6, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_7: (p3_7, 7, 7, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+        ]
+        P4x: [
+            P4_0: (p4_0, 0,  8, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_1: (p4_1, 1,  9, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_2: (p4_2, 2, 10, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_3: (p4_3, 3, 11, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_4: (p4_4, 4, 12, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_5: (p4_5, 5, 13, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_6: (p4_6, 6, 14, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_7: (p4_7, 7, 15, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+        ]
+    }
+    (portc, pcdir, pcout, pcin, pcren, pcsel0, pcsel1, PCx): {
+        P5x: [
+            P5_0: (p5_0, 0, 0, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_1: (p5_1, 1, 1, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_2: (p5_2, 2, 2, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_3: (p5_3, 3, 3, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_4: (p5_4, 4, 4, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_5: (p5_5, 5, 5, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_6: (p5_6, 6, 6, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_7: (p5_7, 7, 7, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+        ]
+        P6x: [
+            P6_0: (p6_0, 0,  8, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_1: (p6_1, 1,  9, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_2: (p6_2, 2, 10, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_3: (p6_3, 3, 11, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_4: (p6_4, 4, 12, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_5: (p6_5, 5, 13, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_6: (p6_6, 6, 14, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_7: (p6_7, 7, 15, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+        ]
+    }
+    (portd, pddir, pdout, pdin, pdren, pdsel0, pdsel1, PDx): {
+        P7x: [
+            P7_0: (p7_0, 0, 0, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_1: (p7_1, 1, 1, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_2: (p7_2, 2, 2, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_3: (p7_3, 3, 3, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_4: (p7_4, 4, 4, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_5: (p7_5, 5, 5, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_6: (p7_6, 6, 6, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_7: (p7_7, 7, 7, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+        ]
+        P8x: [
+            P8_0: (p8_0, 0,  8, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_1: (p8_1, 1,  9, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_2: (p8_2, 2, 10, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_3: (p8_3, 3, 11, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_4: (p8_4, 4, 12, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_5: (p8_5, 5, 13, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_6: (p8_6, 6, 14, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_7: (p8_7, 7, 15, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+        ]
+    }
+    (porte, pedir, peout, pein, peren, pesel0, pesel1, PEx): {
+        P9x: [
+            P9_0: (p9_0, 0, 0, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_1: (p9_1, 1, 1, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_2: (p9_2, 2, 2, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_3: (p9_3, 3, 3, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_4: (p9_4, 4, 4, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_5: (p9_5, 5, 5, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_6: (p9_6, 6, 6, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_7: (p9_7, 7, 7, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+        ]
+        P10x: [
+            P10_0: (p10_0, 0,  8, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_1: (p10_1, 1,  9, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_2: (p10_2, 2, 10, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_3: (p10_3, 3, 11, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_4: (p10_4, 4, 12, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_5: (p10_5, 5, 13, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_6: (p10_6, 6, 14, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_7: (p10_7, 7, 15, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+        ]
+    }
 });

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-pub use hal::digital::{InputPin, OutputPin, ToggleableOutputPin};
+pub use hal::digital::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
@@ -40,6 +40,11 @@ pub struct Primary;
 pub struct Secondary;
 pub struct Tertiary;
 
+pub enum Edge {
+  Rising,
+  Falling,
+}
+
 /// Extension trait to split a GPIO peripheral in independent pins and registers
 pub trait GpioExt {
     /// The to split the GPIO into
@@ -51,9 +56,9 @@ pub trait GpioExt {
 
 macro_rules! gpio {
     ($DIO:ident, {
-        $(($portx:ident, $pxdir:ident, $pxout:ident, $pxin:ident, $pxren:ident, $pxsel0:ident, $pxsel1:ident, $PXx:ident): {
+        $(($portx:ident, $pxdir:ident, $pxout:ident, $pxin:ident, $pxren:ident, $pxsel0:ident, $pxsel1:ident, $pxie:ident, $pxies:ident, $pxifg:ident, $PXx:ident): {
           $($PIx:ident: [
-            $($PI_i:ident: ($pxi:ident, $i:expr, $j:expr, $pidir:ident, $piout:ident, $piin:ident, $piren:ident, $pisel0:ident, $pisel1:ident, $MODE:ty),)+
+            $($PI_i:ident: ($pxi:ident, $i:expr, $j:expr, $pidir:ident, $piout:ident, $piin:ident, $piren:ident, $pisel0:ident, $pisel1:ident, $piie:ident, $piies:ident, $piifg:ident, $MODE:ty),)+
           ])+
         })+
     }) => {
@@ -171,9 +176,65 @@ macro_rules! gpio {
                             }
                         }
 
+                        impl<MODE> $PI_i<Input<MODE>> {
+                          pub fn trigger_on_edge(&mut self, edge: Edge) {
+                            let dio = unsafe { &*$DIO::ptr() };
+
+                              match edge {
+                                  Edge::Rising => {
+                                    dio.$pxies.modify(|r, w| unsafe {
+                                      w.$piies().bits(r.$piies().bits() & !(1 << $i))
+                                    });
+                                  },
+                                  Edge::Falling => {
+                                    dio.$pxies.modify(|r, w| unsafe {
+                                      w.$piies().bits(r.$piies().bits() | (1 << $i))
+                                    });
+                                  }
+                              }
+                          }
+
+                            #[inline]
+                            pub fn enable_interrupt(&mut self) {
+                              let dio = unsafe { &*$DIO::ptr() };
+                              dio.$pxie.modify(|r, w| unsafe {
+                                w.$piie().bits(r.$piie().bits() | (0x01 << $i))
+                              });
+                            }
+
+                            #[inline]
+                            pub fn disable_interrupt(&mut self) {
+                              let dio = unsafe { &*$DIO::ptr() };
+                              dio.$pxie.modify(|r, w| unsafe {
+                                w.$piie().bits(r.$piie().bits() & !(0x01 << $i))
+                              });
+                            }
+
+                            #[inline]
+                            pub fn interrupt_enabled(&self) -> bool {
+                              let dio = unsafe { &*$DIO::ptr() };
+                              dio.$pxie.read().bits() & (0x01 << $i) != 0
+                            }
+
+                            #[inline]
+                            pub fn clear_interrupt_pending_bit(&mut self) {
+                              let dio = unsafe { &*$DIO::ptr() };
+                              dio.$pxifg.modify(|r, w| unsafe {
+                                w.$piifg().bits(r.$piifg().bits() & !(1 << $i))
+                              });
+                            }
+
+                            #[inline]
+                            pub fn check_interrupt(&mut self) -> bool {
+                              let dio = unsafe { &*$DIO::ptr() };
+                              dio.$pxifg.read().$piifg().bits() & (1 << $i) != 0
+                            }
+                        }
+
                         impl<MODE> InputPin for $PI_i<Input<MODE>> {
                             type Error = Infallible;
 
+                            #[inline]
                             fn try_is_high(&self) -> Result<bool, Self::Error> {
                                 self.try_is_low().map(|low| !low)
                             }
@@ -244,114 +305,114 @@ macro_rules! gpio {
 use pac::DIO;
 
 gpio!(DIO, {
-    (porta, padir, paout, pain, paren, pasel0, pasel1, PAx): {
+    (porta, padir, paout, pain, paren, pasel0, pasel1, paie, paies, paifg, PAx): {
         P1x: [
-            P1_0: (p1_0, 0, 0, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_1: (p1_1, 1, 1, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_2: (p1_2, 2, 2, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_3: (p1_3, 3, 3, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_4: (p1_4, 4, 4, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_5: (p1_5, 5, 5, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_6: (p1_6, 6, 6, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
-            P1_7: (p1_7, 7, 7, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, Input<Floating>),
+            P1_0: (p1_0, 0, 0, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_1: (p1_1, 1, 1, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_2: (p1_2, 2, 2, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_3: (p1_3, 3, 3, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_4: (p1_4, 4, 4, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_5: (p1_5, 5, 5, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_6: (p1_6, 6, 6, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
+            P1_7: (p1_7, 7, 7, p1dir, p1out, p1in, p1ren, p1sel0, p1sel1, p1ie, p1ies, p1ifg, Input<Floating>),
         ]
         P2x: [
-            P2_0: (p2_0, 0,  8, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_1: (p2_1, 1,  9, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_2: (p2_2, 2, 10, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_3: (p2_3, 3, 11, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_4: (p2_4, 4, 12, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_5: (p2_5, 5, 13, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_6: (p2_6, 6, 14, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
-            P2_7: (p2_7, 7, 15, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, Input<Floating>),
+            P2_0: (p2_0, 0,  8, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_1: (p2_1, 1,  9, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_2: (p2_2, 2, 10, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_3: (p2_3, 3, 11, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_4: (p2_4, 4, 12, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_5: (p2_5, 5, 13, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_6: (p2_6, 6, 14, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
+            P2_7: (p2_7, 7, 15, p2dir, p2out, p2in, p2ren, p2sel0, p2sel1, p2ie, p2ies, p2ifg, Input<Floating>),
         ]
     }
-    (portb, pbdir, pbout, pbin, pbren, pbsel0, pbsel1, PBx): {
+    (portb, pbdir, pbout, pbin, pbren, pbsel0, pbsel1, pbie, pbies, pbifg, PBx): {
         P3x: [
-            P3_0: (p3_0, 0, 0, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_1: (p3_1, 1, 1, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_2: (p3_2, 2, 2, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_3: (p3_3, 3, 3, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_4: (p3_4, 4, 4, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_5: (p3_5, 5, 5, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_6: (p3_6, 6, 6, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
-            P3_7: (p3_7, 7, 7, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, Input<Floating>),
+            P3_0: (p3_0, 0, 0, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_1: (p3_1, 1, 1, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_2: (p3_2, 2, 2, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_3: (p3_3, 3, 3, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_4: (p3_4, 4, 4, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_5: (p3_5, 5, 5, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_6: (p3_6, 6, 6, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
+            P3_7: (p3_7, 7, 7, p3dir, p3out, p3in, p3ren, p3sel0, p3sel1, p3ie, p3ies, p3ifg, Input<Floating>),
         ]
         P4x: [
-            P4_0: (p4_0, 0,  8, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_1: (p4_1, 1,  9, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_2: (p4_2, 2, 10, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_3: (p4_3, 3, 11, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_4: (p4_4, 4, 12, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_5: (p4_5, 5, 13, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_6: (p4_6, 6, 14, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
-            P4_7: (p4_7, 7, 15, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, Input<Floating>),
+            P4_0: (p4_0, 0,  8, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_1: (p4_1, 1,  9, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_2: (p4_2, 2, 10, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_3: (p4_3, 3, 11, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_4: (p4_4, 4, 12, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_5: (p4_5, 5, 13, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_6: (p4_6, 6, 14, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
+            P4_7: (p4_7, 7, 15, p4dir, p4out, p4in, p4ren, p4sel0, p4sel1, p4ie, p4ies, p4ifg, Input<Floating>),
         ]
     }
-    (portc, pcdir, pcout, pcin, pcren, pcsel0, pcsel1, PCx): {
+    (portc, pcdir, pcout, pcin, pcren, pcsel0, pcsel1, pcie, pcies, pcifg, PCx): {
         P5x: [
-            P5_0: (p5_0, 0, 0, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_1: (p5_1, 1, 1, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_2: (p5_2, 2, 2, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_3: (p5_3, 3, 3, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_4: (p5_4, 4, 4, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_5: (p5_5, 5, 5, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_6: (p5_6, 6, 6, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
-            P5_7: (p5_7, 7, 7, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, Input<Floating>),
+            P5_0: (p5_0, 0, 0, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_1: (p5_1, 1, 1, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_2: (p5_2, 2, 2, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_3: (p5_3, 3, 3, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_4: (p5_4, 4, 4, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_5: (p5_5, 5, 5, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_6: (p5_6, 6, 6, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
+            P5_7: (p5_7, 7, 7, p5dir, p5out, p5in, p5ren, p5sel0, p5sel1, p5ie, p5ies, p5ifg, Input<Floating>),
         ]
         P6x: [
-            P6_0: (p6_0, 0,  8, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_1: (p6_1, 1,  9, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_2: (p6_2, 2, 10, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_3: (p6_3, 3, 11, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_4: (p6_4, 4, 12, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_5: (p6_5, 5, 13, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_6: (p6_6, 6, 14, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
-            P6_7: (p6_7, 7, 15, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, Input<Floating>),
+            P6_0: (p6_0, 0,  8, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_1: (p6_1, 1,  9, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_2: (p6_2, 2, 10, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_3: (p6_3, 3, 11, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_4: (p6_4, 4, 12, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_5: (p6_5, 5, 13, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_6: (p6_6, 6, 14, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
+            P6_7: (p6_7, 7, 15, p6dir, p6out, p6in, p6ren, p6sel0, p6sel1, p6ie, p6ies, p6ifg, Input<Floating>),
         ]
     }
-    (portd, pddir, pdout, pdin, pdren, pdsel0, pdsel1, PDx): {
+    (portd, pddir, pdout, pdin, pdren, pdsel0, pdsel1, pdie, pdies, pdifg, PDx): {
         P7x: [
-            P7_0: (p7_0, 0, 0, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_1: (p7_1, 1, 1, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_2: (p7_2, 2, 2, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_3: (p7_3, 3, 3, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_4: (p7_4, 4, 4, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_5: (p7_5, 5, 5, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_6: (p7_6, 6, 6, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
-            P7_7: (p7_7, 7, 7, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, Input<Floating>),
+            P7_0: (p7_0, 0, 0, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_1: (p7_1, 1, 1, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_2: (p7_2, 2, 2, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_3: (p7_3, 3, 3, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_4: (p7_4, 4, 4, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_5: (p7_5, 5, 5, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_6: (p7_6, 6, 6, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
+            P7_7: (p7_7, 7, 7, p7dir, p7out, p7in, p7ren, p7sel0, p7sel1, p7ie, p7ies, p7ifg, Input<Floating>),
         ]
         P8x: [
-            P8_0: (p8_0, 0,  8, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_1: (p8_1, 1,  9, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_2: (p8_2, 2, 10, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_3: (p8_3, 3, 11, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_4: (p8_4, 4, 12, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_5: (p8_5, 5, 13, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_6: (p8_6, 6, 14, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
-            P8_7: (p8_7, 7, 15, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, Input<Floating>),
+            P8_0: (p8_0, 0,  8, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_1: (p8_1, 1,  9, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_2: (p8_2, 2, 10, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_3: (p8_3, 3, 11, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_4: (p8_4, 4, 12, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_5: (p8_5, 5, 13, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_6: (p8_6, 6, 14, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
+            P8_7: (p8_7, 7, 15, p8dir, p8out, p8in, p8ren, p8sel0, p8sel1, p8ie, p8ies, p8ifg, Input<Floating>),
         ]
     }
-    (porte, pedir, peout, pein, peren, pesel0, pesel1, PEx): {
+    (porte, pedir, peout, pein, peren, pesel0, pesel1, peie, peies, peifg, PEx): {
         P9x: [
-            P9_0: (p9_0, 0, 0, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_1: (p9_1, 1, 1, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_2: (p9_2, 2, 2, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_3: (p9_3, 3, 3, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_4: (p9_4, 4, 4, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_5: (p9_5, 5, 5, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_6: (p9_6, 6, 6, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
-            P9_7: (p9_7, 7, 7, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, Input<Floating>),
+            P9_0: (p9_0, 0, 0, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_1: (p9_1, 1, 1, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_2: (p9_2, 2, 2, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_3: (p9_3, 3, 3, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_4: (p9_4, 4, 4, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_5: (p9_5, 5, 5, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_6: (p9_6, 6, 6, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
+            P9_7: (p9_7, 7, 7, p9dir, p9out, p9in, p9ren, p9sel0, p9sel1, p9ie, p9ies, p9ifg, Input<Floating>),
         ]
         P10x: [
-            P10_0: (p10_0, 0,  8, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_1: (p10_1, 1,  9, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_2: (p10_2, 2, 10, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_3: (p10_3, 3, 11, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_4: (p10_4, 4, 12, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_5: (p10_5, 5, 13, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_6: (p10_6, 6, 14, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
-            P10_7: (p10_7, 7, 15, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, Input<Floating>),
+            P10_0: (p10_0, 0,  8, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_1: (p10_1, 1,  9, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_2: (p10_2, 2, 10, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_3: (p10_3, 3, 11, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_4: (p10_4, 4, 12, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_5: (p10_5, 5, 13, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_6: (p10_6, 6, 14, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
+            P10_7: (p10_7, 7, 15, p10dir, p10out, p10in, p10ren, p10sel0, p10sel1, p10ie, p10ies, p10ifg, Input<Floating>),
         ]
     }
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,4 @@ pub mod gpio;
 pub mod time;
 pub mod clock;
 pub mod pcm;
-pub mod flctl;
+// pub mod flctl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,4 @@ pub mod gpio;
 pub mod time;
 pub mod clock;
 pub mod pcm;
-// pub mod flctl;
+pub mod flctl;

--- a/src/pcm.rs
+++ b/src/pcm.rs
@@ -40,7 +40,7 @@ impl State for PcmNotDefined {}
 
 impl State for PcmDefined {}
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum VCoreSel {
     LdoVcore0,
     LdoVcore1,
@@ -64,7 +64,7 @@ impl VCoreSel {
     }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum VCoreCheck {
     LdoVcore0,
     LdoVcore1,


### PR DESCRIPTION
Get pins by splitting the `DIO` peripheral rather than creating them from thin air.