### PR TITLE
Restricting embedded-hal dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
 msp432p401r-pac = {version = "0.2.0", features = ["rt"]}
 cortex-m-semihosting = "0.3.3"
-embedded-hal = "1.0.0-alpha.4"
+embedded-hal = "=1.0.0-alpha.4"
 nb = "1.0.0"
 
 [profile.dev]


### PR DESCRIPTION
This will lock embedded-hal to `1.0.0-alpha.4`, avoiding breaks in main branch